### PR TITLE
corrected NLP2 python, added comments

### DIFF
--- a/python/readingFileCollection.py
+++ b/python/readingFileCollection.py
@@ -46,21 +46,22 @@ def readTextFiles(filepath):
         tokens = nlp(stringFile)
         # playing with vectors here
         vectors = tokens.vector
-
+        # 2023-02-26 ebb: The line below is where you set your word of interest.
         wordOfInterest = nlp(u'panic')
         # print(wordOfInterest, ': ', wordOfInterest.vector_norm)
 
         # Now, let's open an empty dictionary! We'll fill it up with the for loop just after it.
         # The for-loop goes over each token and gets its values
-        highSimilarityDict = {"The_Silmarillion.txt", "web.txt"}
-        sortedhighSimilarityDict = sorted(highSimilarityDict)
-
-        print(sortedhighSimilarityDict)
+        highSimilarityDict = {}
+        # sortedhighSimilarityDict = sorted(highSimilarityDict)
+        # 2023-02-06 ebb: The highSimlarityDict needs to be empty up here.
+        # ebb: It will be populated by the for loop. This is a pretty common Python strategy
+        # to create an empty data structure and then run a for-loop to fill it.
 
         for token in tokens:
             if(token and token.vector_norm):
                 # if token not in highSimilarityDict.keys(): # Alas, this did not work to remove duplicates from my dictionary. :-(
-                if wordOfInterest.similarity(token) > .3:
+                if wordOfInterest.similarity(token) > .5:
                     highSimilarityDict[token] = wordOfInterest.similarity(token)
                     # The line above creates the structure for each entry in my dictionary.
                          # print(token.text, "about this much similar to", wordOfInterest, ": ", wordOfInterest.similarity(token))


### PR DESCRIPTION
@Stach13 I made some significant corrections to debug your readingFileCollections.py script: your dictionary wasn't able to populate because you'd set your files in it. It's supposed to be holding word tokens at that point in the script. 

Basically when the `def readTextFiles(filepath):` function starts running, it is being fed one file at a time from your directory. So everything inside that function opens up the file and pulls the words / tokens out of it, and runs nlp() over them from the spaCy library. You were trying to set up the dictionary to have file contents--and that was causing the code to trip over itself (it already had a file in hand to process). 

I left some comments in the code to help you adapt and continue, so I hope you'll accept this Pull Request, merge this in, and continue with this debugged version of your code. 

In answer to your question on Canvas, the wordOfInterest is defined around line 50--and you can reset it there. 

